### PR TITLE
Fix length arg to connect() call so it works on Mac

### DIFF
--- a/netflow5_generator.cpp
+++ b/netflow5_generator.cpp
@@ -26,7 +26,7 @@ int Netflow5Generator::start() {
     m_sockets = new int[getNumThreads()];
     for (int i = 0; i < getNumThreads(); ++i) {
         m_sockets[i] = socket(AF_INET, SOCK_DGRAM, 0);
-        if (connect(m_sockets[i], (sockaddr *)&m_dest, sizeof(m_dest)) < 0) {
+        if (connect(m_sockets[i], (sockaddr *)&m_dest, sizeof(struct sockaddr)) < 0) {
             perror("connect()");
             return -1;
         }

--- a/netflow9_generator.cpp
+++ b/netflow9_generator.cpp
@@ -49,7 +49,7 @@ int Netflow9Generator::start() {
     m_sockets = new int[getNumThreads()];
     for (int i = 0; i < getNumThreads(); ++i) {
         m_sockets[i] = socket(AF_INET, SOCK_DGRAM, 0);
-        if (connect(m_sockets[i], (sockaddr *)&m_dest, sizeof(m_dest)) < 0) {
+        if (connect(m_sockets[i], (sockaddr *)&m_dest, sizeof(struct sockaddr)) < 0) {
             perror("connect()");
             return -1;
         }

--- a/syslog_generator.cpp
+++ b/syslog_generator.cpp
@@ -20,7 +20,7 @@ int SyslogGenerator::start() {
     m_sockets = new int[getNumThreads()];
     for (int i = 0; i < getNumThreads(); ++i) {
         m_sockets[i] = socket(AF_INET, SOCK_DGRAM, 0);
-        if (connect(m_sockets[i], (sockaddr *)&m_dest, sizeof(m_dest)) < 0) {
+        if (connect(m_sockets[i], (sockaddr *)&m_dest, sizeof(struct sockaddr)) < 0) {
             perror("connect()");
             return -1;
         }


### PR DESCRIPTION
As the summary says. MacOS is picky about the length argument and passing in `sizeof(m_dest)` which is a `struct sockaddr_storage` is invalid for the argument which is a `struct sockaddr`.