### PR TITLE
Add -s and -S options to exit after N packets/seconds

### DIFF
--- a/udp_generator.hpp
+++ b/udp_generator.hpp
@@ -30,6 +30,9 @@ public:
     void setNumPacketsPerSend(unsigned int num_packets);
     unsigned int getNumPacketsPerSend();
 
+    void setStopAfterPackets(unsigned int packets);
+    void setStopAfterSeconds(unsigned int seconds);
+
     virtual int start();
     virtual void stop();
 
@@ -49,6 +52,8 @@ private:
     double m_packets_per_second = 10000;
     int m_report_interval = 10;
     unsigned int m_num_packets_per_send = 1;
+    unsigned int m_stopAfterPackets = 0;
+    unsigned int m_stopAfterSeconds = 0;
 
     unsigned long long m_report_every_n_packets;
     bool m_stopped;


### PR DESCRIPTION
This PR adds two new options to the udpgen command line:
  `-s N` causes it to stop (exit) after sending N packets (per thread)
  `-S N` causes it to stop (exit) after N seconds (from start of the first thread)

These are not 100% accurate since packets are sent in groups. The tool will exit after a group if the specified threshold has been exceeded.

Specifying either exit condition inhibits "interactive" mode. The process can still be stopped with Ctrl-C and prints statistics as usual. Both conditions can be specified and it will exit upon hitting either threshold - but this is dumb, so don't do it. :)
