### PR TITLE
chg: Upate container base image and publish latest version on DockerHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   docker-executor:
     docker:
-      - image: docker:19.03.0-git
+      - image: docker:git
 
 commands:
   docker-registry-login:
@@ -22,7 +22,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: buildpack-deps:focal
+      - image: buildpack-deps:jammy
     steps:
       - checkout
       - run:
@@ -76,7 +76,6 @@ jobs:
           name: Publish to DockerHub
           command: |
             docker push opennms/udpgen:latest
-
 
 workflows:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM ubuntu:20.04
-LABEL license="AGPLv3" \
-      vendor="The OpenNMS Group, Inc." \
-      name="udpgen"
-RUN apt update && apt install -y \
-    libsnmp35 \
-    net-tools \
-    iputils-ping \
-    tcpdump \
-&& rm -rf /var/lib/apt/lists/*
+FROM ubuntu:jammy-20231128
+
+RUN apt-get update && \
+    apt-get install -y libsnmp40 \
+      net-tools \
+      iputils-ping \
+      tcpdump && \
+      rm -rf /var/lib/apt/lists/*
+
 COPY build/udpgen udpgen
-CMD ["/udpgen", "-i", "-r", "1",  "-t", "1", "-h", "127.0.0.1", "-p", "514"]
+
+ENTRYPOINT [ "/udpgen" ]
+
+LABEL org.opencontainers.image.description="udpgen - A cli tool to generate SNMP Traps, Syslog and NetFlow v9 packets" \
+      org.opencontainers.image.source="https://github.com/opennms/udpgen.git" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="ronny@opennms.org" \
+      org.opencontainers.image.licenses="AGPLv3"

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ make
 * `-p`: Target port (default: depends on mode)
 * `-r`: Rate - number of packets per second to generate (default: 10000) Set the rate to 0 in order to disable rate limiting
 * `-s`: Send X number of packets and then stop
-* `-s`: Senx packets for X number of seconds and then stop
-*  `-t`: Number of threads used to generate packets (default: 1)
+* `-S`: Senx packets for X number of seconds and then stop
+* `-t`: Number of threads used to generate packets (default: 1)
 * `-z`: Number of packets per iteration (default: 1) Increase this when sending packets at a high rate
 
 ## Examples


### PR DESCRIPTION
Update the base image to use latest Ubuntu base image and use the /udpgen binary as entrypoint. When no argument is set the udpgen tool gives a a help as output. To avoid mistakes we just print the help on container start and don't generate UDP traffic accidentally.

Fixed the readme typo for -S to indicate a given limit by seconds